### PR TITLE
No cache for show_tables(show_all=True) on NZ

### DIFF
--- a/nzpyida/base.py
+++ b/nzpyida/base.py
@@ -610,7 +610,7 @@ class IdaDataBase(object):
         ####
 
         # Try to retrieve the cache
-        if show_all:
+        if show_all and not self._is_netezza_system():
             cache = self._retrieve_cache("cache_show_tables")
             if cache is not None:
                 return cache


### PR DESCRIPTION
This is a fix for https://github.com/IBM/nzpyida/issues/6.

In the fix, I decided to only change the behavior in case on Netezza - for Db2 is stays as it was.