### PR TITLE
Fixing double aliasing of NZ SQL

### DIFF
--- a/nzpyida/internals.py
+++ b/nzpyida/internals.py
@@ -294,16 +294,21 @@ class InternalState(object):
                 #if columns == "*":
                     #columns = "\"" + "\",\"".join(self._idadf.columns) + "\""
 
+                if self._idadf._idadb._is_netezza_system():
+                    order_by = "ORDER BY NULL"
+                    as_temp1 = ""
+                    temp1 = ""
+                else:
+                    order_by = ""
+                    as_temp1 = "AS TEMP1"
+                    temp1 = "TEMP1."
+
                 if self._idadf.indexer:
-                    query = ("SELECT " + columns + " FROM %s AS TEMP1 WHERE " +
+                    query = ("SELECT " + columns + " FROM %s " + as_temp1 + " WHERE " +
                              self._idadf.indexer + indexstring)
                 else:
-                    if self._idadf._idadb._is_netezza_system():
-                        order_by = "ORDER BY NULL"
-                    else:
-                        order_by = ""
-                    query = ("SELECT " + columns + " FROM (SELECT TEMP1.*, "+
-                            "(ROW_NUMBER() OVER(" + order_by + ")-1) AS RN FROM %s AS TEMP1) AS TEMP2 "+
+                    query = ("SELECT " + columns + " FROM (SELECT " + temp1 + "*, "+
+                            "(ROW_NUMBER() OVER(" + order_by + ")-1) AS RN FROM %s " + as_temp1 + ") AS TEMP2 "+
                             "WHERE RN " + indexstring)
 
                 self.index = None


### PR DESCRIPTION
This PR fixes issue https://github.com/IBM/nzpyida/issues/11.

The code basically excludes aliasing in update() function for NZ queries as the aliasing it is already performed in more generic get_state() function.

With this fix (as also https://github.com/IBM/nzpyida/commit/2ed98aba2aa3dac8b4047440a7a00a0798417efc for which I'm going to open another PR), unit tests completes succesfully.

```
Fri 7 10:14 tests % python3 -m pytest --hostname 9.30.57.160 --dsn telco --uid admin --pwd password
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.9.6, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/mlabenski/PycharmProjects/nzpyida
plugins: anyio-3.6.2, flaky-3.7.0
collected 494 items                                                                                                                                         

test_aggregation.py .................................                                                                                                 [  6%]
test_association_rules.py .........                                                                                                                   [  8%]
test_base.py .....s........ss..............                                                                                                           [ 14%]
test_base_connexion.py ............                                                                                                                   [ 17%]
test_base_private.py ......................                                                                                                           [ 21%]
test_base_table_manipulation.py ..s..ssss..................                                                                                           [ 26%]
test_feature_selection.py ssssssssssss..........................................                                                                      [ 37%]
test_filtering.py ..........                                                                                                                          [ 39%]
test_frame.py ....................................................................s....                                                               [ 54%]
test_frame_connexion.py ......                                                                                                                        [ 55%]
test_frame_private.py ........................                                                                                                        [ 60%]
test_geoFrame.py sssssssssssssssssssssssssssssss                                                                                                      [ 67%]
test_geoSeries.py sssssssssssssssssssssssssssssssssssssssssssssssss                                                                                   [ 76%]
test_indexing.py .....................                                                                                                                [ 81%]
test_internals.py .....                                                                                                                               [ 82%]
test_kmeans.py .........                                                                                                                              [ 84%]
test_naive_bayes.py .........                                                                                                                         [ 85%]
test_series.py ...                                                                                                                                    [ 86%]
test_sorting.py ............                                                                                                                          [ 88%]
test_statistics.py .................................................                                                                                  [ 98%]
test_utils.py ......                                                                                                                                  [100%]

===================================================================== warnings summary ======================================================================

...


================================================ 393 passed, 101 skipped, 160 warnings in 721.33s (0:12:01) =================================================

```