### PR TITLE
Change conftest, add function to docs and init

### DIFF
--- a/docs/source/predictive.rst
+++ b/docs/source/predictive.rst
@@ -80,3 +80,19 @@ Predictive Modeling base module
    :members:
    :undoc-members:
    :show-inheritance:
+
+Bisecting KMeans
+-----------------------------------------------------
+
+.. automodule:: nzpyida.analytics.predictive.bisecting_kmeans
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Two Step Clustering
+-----------------------------------------------------
+
+.. automodule:: nzpyida.analytics.predictive.two_step_clustering
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/nzpyida/analytics/__init__.py
+++ b/nzpyida/analytics/__init__.py
@@ -13,6 +13,10 @@ from .predictive.kmeans import KMeans
 from .predictive.knn import KNeighborsClassifier
 from .predictive.linear_regression import LinearRegression
 from .predictive.naive_bayes import NaiveBayesClassifier
+from .predictive.association_rules import ARule
+from .predictive.bisecting_kmeans import BisectingKMeans
+from .predictive.regression_trees import DecisionTreeRegressor
+from .predictive.two_step_clustering import TwoStepClustering
 from .exploration.distribution import bitable, moments, histogram, outliers
 from .exploration.distribution import quantile, unitable
 from .transform.discretization import EFDisc, EMDisc, EWDisc
@@ -20,3 +24,7 @@ from .transform.discretization import ef_disc, em_disc, ew_disc
 from .transform.preparation import std_norm, impute_data, random_sample
 from .model_manager import ModelManager
 from .auto_delete_context import AutoDeleteContext
+from .exploration.relation_identification import corr, cov, covariance_matrix, \
+spearman_corr, mutual_info, chisq, t_me_test, t_ls_test, t_pmd_test, t_umd_test, \
+mww_test, wilcoxon_test, canonical_corr, anova_crd_test, anova_rbd_test, \
+manova_one_way_test, manova_two_way_test

--- a/nzpyida/analytics/tests/conftest.py
+++ b/nzpyida/analytics/tests/conftest.py
@@ -15,25 +15,14 @@ from nzpyida.base import IdaDataBase
 @pytest.fixture(scope='session')
 def idadb():
     nzpy_cfg = {
-        "user":"admin",
-        "password":"password", 
-        "host":'127.0.0.1', 
+        "user":"username",
+        "password":"*****", 
+        "host":'hostname', 
         "port":5480, 
-        "database":"wrappers_tests", 
+        "database":"database_name", 
         "logLevel":0, 
         "securityLevel":1
     }
-    
-    nzpy_cfg_fyre = {
-        "user":"admin",
-        "password":"password", 
-        "host":'9.30.57.160', 
-        "port":5480, 
-        "database":"telco", 
-        "logLevel":0, 
-        "securityLevel":1
-    }
-
     return IdaDataBase(nzpy_cfg)
 
 df_train = pd.DataFrame.from_dict({"ID": range(1000),

--- a/nzpyida/analytics/tests/test_association_rules.py
+++ b/nzpyida/analytics/tests/test_association_rules.py
@@ -82,18 +82,18 @@ def test_arule(idadb: IdaDataBase, mm: ModelManager, idf_test: IdaDataFrame,
               support_type='absolute', support=2, confidence=0.4)
     assert mm.model_exists(MOD_NAME) 
 
-    pred = model.predict(idf_test, OUT_TABLE_PRED, max_conviction=1.25, 
+    pred_ida = model.predict(idf_test, OUT_TABLE_PRED, max_conviction=1.25, 
                        max_affinity=0.6, min_lift=1.0, min_leverage=0.03)
-    assert pred
-    assert all(pred.columns == ['GID', 'TID', 'LHS_SID', 'RHS_SID', 'LHS_ITEMS', 'RHS_ITEMS', 'SUPPORT',
+    assert pred_ida
+    assert all(pred_ida.columns == ['GID', 'TID', 'LHS_SID', 'RHS_SID', 'LHS_ITEMS', 'RHS_ITEMS', 'SUPPORT',
        'CONFIDENCE', 'LIFT', 'CONVICTION', 'AFFINITY', 'LEVERAGE'])
-    pred_len = len(pred)
-    assert all(pred.head(pred_len)["SUPPORT"].values >= 0.2)
-    assert all(pred.head(pred_len)["CONFIDENCE"].values >= 0.4)
-    assert all(pred.head(pred_len)["CONVICTION"].values <= 1.25)
-    assert all(pred.head(pred_len)["AFFINITY"].values <= 0.6)
-    assert all(pred.head(pred_len)["LIFT"].values >= 1.0)
-    assert all(pred.head(pred_len)["LEVERAGE"].values >=0.03)
+    pred = pred_ida.as_dataframe()
+    assert all(pred["SUPPORT"].values >= 0.2)
+    assert all(pred["CONFIDENCE"].values >= 0.4)
+    assert all(pred["CONVICTION"].values <= 1.25)
+    assert all(pred["AFFINITY"].values <= 0.6)
+    assert all(pred["LIFT"].values >= 1.0)
+    assert all(pred["LEVERAGE"].values >=0.03)
 
     assert model.describe()
     

--- a/nzpyida/analytics/tests/test_bisecting_kmeans.py
+++ b/nzpyida/analytics/tests/test_bisecting_kmeans.py
@@ -59,7 +59,7 @@ def test_bisecting_kmeans(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, level=5, out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'CLUSTER_ID', 'DISTANCE'])
-    assert all(list(pred.head()['CLUSTER_ID'].values))
+    assert all(list(pred.as_dataframe()['CLUSTER_ID'].values))
 
     score = model.score(idf_test, target_column="A")
 

--- a/nzpyida/analytics/tests/test_decision_trees.py
+++ b/nzpyida/analytics/tests/test_decision_trees.py
@@ -59,7 +59,7 @@ def test_decision_trees(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, id_column="ID", out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'CLASS'])
-    assert list(pred.head()['CLASS'].values) in (['p', 'n', 'n'], ['p', 'p', 'n'])
+    assert list(pred.as_dataframe()['CLASS'].values) in (['p', 'n', 'n'], ['p', 'p', 'n'])
 
     score = model.score(idf_test, id_column="ID", target_column="B")
 
@@ -70,6 +70,6 @@ def test_decision_trees(idadb: IdaDataBase, mm: ModelManager, clear_up):
     assert all([cm, acc, wacc])
     assert all(cm.columns == ['REAL', 'PREDICTION', 'CNT'])
     assert len(cm) >= 2
-    assert sum(cm.head()["CNT"].values) == 3
+    assert sum(cm.as_dataframe()["CNT"].values) == 3
     assert wacc >= 0.75
     assert acc >= 0.66

--- a/nzpyida/analytics/tests/test_kmeans.py
+++ b/nzpyida/analytics/tests/test_kmeans.py
@@ -58,7 +58,7 @@ def test_kmeans(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'CLUSTER_ID', 'DISTANCE'])
-    assert all(list(pred.head()['CLUSTER_ID'].values))
+    assert all(list(pred.as_dataframe()['CLUSTER_ID'].values))
 
     score = model.score(idf_test, target_column="A")
 

--- a/nzpyida/analytics/tests/test_knn.py
+++ b/nzpyida/analytics/tests/test_knn.py
@@ -70,6 +70,6 @@ def test_knn(idadb: IdaDataBase, mm: ModelManager, clear_up):
     assert all([cm, acc, wacc])
     assert all(cm.columns == ['REAL', 'PREDICTION', 'CNT'])
     assert len(cm) >= 3
-    assert sum(cm.head()["CNT"].values) == 3
+    assert sum(cm.as_dataframe()["CNT"].values) == 3
     assert wacc == 0.75
     assert 0.67 >= acc >= 0.66

--- a/nzpyida/analytics/tests/test_linear_regression.py
+++ b/nzpyida/analytics/tests/test_linear_regression.py
@@ -59,7 +59,7 @@ def test_linear_regression(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'B'])
-    assert any(round(x) == y for x, y in zip(list(pred.head()['B'].values),  [1, 4, 2223, -999, 11112]))
+    assert any(round(x) == y for x, y in zip(list(pred.as_dataframe()['B'].values),  [1, 4, 2223, -999, 11112]))
 
     score = model.score(idf_test, target_column='B')
 

--- a/nzpyida/analytics/tests/test_model_manager.py
+++ b/nzpyida/analytics/tests/test_model_manager.py
@@ -69,7 +69,9 @@ def test_model_manager(idadb, clear_up):
                    copyright="Copyright (c) 2023. IBM Corp. All rights reserved.", category="DecTree")
     
     assert mm.model_exists(MOD_NAME)
-    lm = mm.list_models().head()
+
+    lm_ida = mm.list_models()
+    lm = lm_ida.as_dataframe()
     lm = lm[lm["MODELNAME"]==MOD_NAME]
     assert len(lm) == 1
     assert lm["OWNER"].iloc[0] == "INZAUSER"

--- a/nzpyida/analytics/tests/test_naive_bayes.py
+++ b/nzpyida/analytics/tests/test_naive_bayes.py
@@ -59,7 +59,7 @@ def test_naive_bayes(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, id_column="ID", out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'CLASS'])
-    assert list(pred.head()['CLASS'].values) == ['p', 'n', 'n']
+    assert list(pred.as_dataframe()['CLASS'].values) == ['p', 'n', 'n']
 
     score = model.score(idf_test, id_column="ID", target_column="B")
 
@@ -70,6 +70,6 @@ def test_naive_bayes(idadb: IdaDataBase, mm: ModelManager, clear_up):
     assert all([cm, acc, wacc])
     assert all(cm.columns == ['REAL', 'PREDICTION', 'CNT'])
     assert len(cm) >= 3
-    assert sum(cm.head()["CNT"].values) == 3
+    assert sum(cm.as_dataframe()["CNT"].values) == 3
     assert wacc == 0.75
     assert 0.67 >= acc >= 0.66

--- a/nzpyida/analytics/tests/test_regression_trees.py
+++ b/nzpyida/analytics/tests/test_regression_trees.py
@@ -55,7 +55,7 @@ def test_regression_trees(idadb: IdaDataBase, mm: ModelManager, clear_up):
     pred = model.predict(idf_test, id_column="ID", out_table=OUT_TABLE_PRED)
     assert pred
     assert all(pred.columns == ['ID', 'CLASS'])
-    # assert any(round(x) == y for x, y in zip(list(pred.head()['CLASS'].values),  [1, 4, 2223, -999, 11112]))
+    # assert any(round(x) == y for x, y in zip(list(pred.as_dataframe()['CLASS'].values),  [1, 4, 2223, -999, 11112]))
 
     score = model.score(idf_test, id_column="ID", target_column="B")
 

--- a/nzpyida/analytics/tests/test_relation_identification.py
+++ b/nzpyida/analytics/tests/test_relation_identification.py
@@ -154,7 +154,7 @@ class TestSpearmanCorr:
         assert len(out_df) == 2
         assert all(out_df["RHO"].head().values == 0)
 
-
+@pytest.mark.skip
 class TestChisq:
     # I believe last assertsion should be stronger (... > 0.95)
     def test_strong_correlation(self, idf, clean_up):
@@ -404,7 +404,7 @@ class TestManovaOneWayTest:
         assert all(out_df.columns == ['ID_TASK', 'ID_MATRIX', 'ROW', 'COL', 'VAL', 'EXPLANATION',
                                       'BONFERRONI_CORR', 'TASK_NAME', 'VARIABLE_NAME'])
         assert len(out_df) == 21
-        assert len(set(out_df['ID_MATRIX'].head(21).values)) == 4
+        assert len(set(out_df['ID_MATRIX'].as_dataframe().values)) == 4
     
     def test_correlated_columns(self, idf, clean_up):
         out_df = manova_one_way_test(idf, in_column=["A","F"], factor1="C", id_column="ID", 
@@ -413,7 +413,7 @@ class TestManovaOneWayTest:
         assert all(out_df.columns == ['ID_TASK', 'ID_MATRIX', 'ROW', 'COL', 'VAL', 'EXPLANATION',
                                       'BONFERRONI_CORR', 'TASK_NAME', 'VARIABLE_NAME'])
         assert len(out_df) == 21
-        assert len(set(out_df['ID_MATRIX'].head(21).values)) == 4
+        assert len(set(out_df['ID_MATRIX'].as_dataframe().values)) == 4
 
 class TestManovaTwoWayTest:
     def test_correlated_columns(self, idf, clean_up):
@@ -423,4 +423,4 @@ class TestManovaTwoWayTest:
         assert all(out_df.columns == ['ID_TASK', 'ID_MATRIX', 'ROW', 'COL', 'VAL', 'EXPLANATION',
                                       'BONFERRONI_CORR', 'TASK_NAME', 'VARIABLE_NAME'])
         assert len(out_df) == 59
-        assert len(set(out_df['ID_MATRIX'].head(59).values)) == 8
+        assert len(set(out_df['ID_MATRIX'].as_dataframe().values)) == 8

--- a/nzpyida/analytics/tests/test_relation_identification.py
+++ b/nzpyida/analytics/tests/test_relation_identification.py
@@ -154,7 +154,6 @@ class TestSpearmanCorr:
         assert len(out_df) == 2
         assert all(out_df["RHO"].head().values == 0)
 
-@pytest.mark.skip
 class TestChisq:
     # I believe last assertsion should be stronger (... > 0.95)
     def test_strong_correlation(self, idf, clean_up):


### PR DESCRIPTION
Unit tests results:
```
============================================================ test session starts ============================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0 -- /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
cachedir: .pytest_cache
rootdir: /Users/pawelmrz/Documents/persistent/nzpyida
plugins: anyio-3.6.2
collected 70 items                                                                                                                          

test_association_rules.py::test_arule PASSED                                                                                          [  1%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_context_present PASSED                                                [  2%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_context_not_present PASSED                                            [  4%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_nested_contexts PASSED                                                [  5%]
test_auto_delete_context.py::TestAddTableToDelete::test_table_not_deleted PASSED                                                      [  7%]
test_auto_delete_context.py::TestAddTableToDelete::test_table_deleted PASSED                                                          [  8%]
test_auto_delete_context.py::TestAddTableToDelete::test_double_tables_deleted PASSED                                                  [ 10%]
test_auto_delete_context.py::TestAddTableToDelete::test_double_table_one_not_deleted PASSED                                           [ 11%]
test_bisecting_kmeans.py::test_bisecting_kmeans PASSED                                                                                [ 12%]
test_decision_trees.py::test_decision_trees PASSED                                                                                    [ 14%]
test_discretization.py::test_ewdisc PASSED                                                                                            [ 15%]
test_discretization.py::test_efdisc PASSED                                                                                            [ 17%]
test_discretization.py::test_emdisc PASSED                                                                                            [ 18%]
test_kmeans.py::test_kmeans PASSED                                                                                                    [ 20%]
test_knn.py::test_knn PASSED                                                                                                          [ 21%]
test_linear_regression.py::test_linear_regression SKIPPED (unconditional skip)                                                        [ 22%]
test_model_manager.py::test_model_manager PASSED                                                                                      [ 24%]
test_naive_bayes.py::test_naive_bayes PASSED                                                                                          [ 25%]
test_preparation.py::test_std_norm PASSED                                                                                             [ 27%]
test_preparation.py::test_random_sample PASSED                                                                                        [ 28%]
test_preparation.py::test_impute_data PASSED                                                                                          [ 30%]
test_regression_trees.py::test_regression_trees PASSED                                                                                [ 31%]
test_relation_identification.py::TestCorr::test_strong_correlation PASSED                                                             [ 32%]
test_relation_identification.py::TestCorr::test_weak_correlation PASSED                                                               [ 34%]
test_relation_identification.py::TestCorr::test_no_correlation PASSED                                                                 [ 35%]
test_relation_identification.py::TestCov::test_strong_covariance PASSED                                                               [ 37%]
test_relation_identification.py::TestCov::test_weak_covariance PASSED                                                                 [ 38%]
test_relation_identification.py::TestCov::test_no_covariance PASSED                                                                   [ 40%]
test_relation_identification.py::TestMutualInfo::test_strong_corelation PASSED                                                        [ 41%]
test_relation_identification.py::TestMutualInfo::test_weak_correlation SKIPPED (unconditional skip)                                   [ 42%]
test_relation_identification.py::TestMutualInfo::test_no_correlation SKIPPED (unconditional skip)                                     [ 44%]
test_relation_identification.py::TestCovarianceMatrix::test_strong_corelation PASSED                                                  [ 45%]
test_relation_identification.py::TestCovarianceMatrix::test_weak_correlation PASSED                                                   [ 47%]
test_relation_identification.py::TestCovarianceMatrix::test_no_correlation PASSED                                                     [ 48%]
test_relation_identification.py::TestSpearmanCorr::test_strong_corelation PASSED                                                      [ 50%]
test_relation_identification.py::TestSpearmanCorr::test_weak_correlation PASSED                                                       [ 51%]
test_relation_identification.py::TestSpearmanCorr::test_no_correlation PASSED                                                         [ 52%]
test_relation_identification.py::TestChisq::test_strong_correlation PASSED                                                            [ 54%]
test_relation_identification.py::TestChisq::test_weak_correlation SKIPPED (unconditional skip)                                        [ 55%]
test_relation_identification.py::TestChisq::test_no_correlation SKIPPED (unconditional skip)                                          [ 57%]
test_relation_identification.py::TestTMeTest::test_linear_column_correct_value PASSED                                                 [ 58%]
test_relation_identification.py::TestTMeTest::test_linear_column_incorrect_value PASSED                                               [ 60%]
test_relation_identification.py::TestTMeTest::test_linear_column_incorrect_value_with_by_column PASSED                                [ 61%]
test_relation_identification.py::TestTMeTest::test_constant_column PASSED                                                             [ 62%]
test_relation_identification.py::TestTUmdTest::test_linear_column_correct_value PASSED                                                [ 64%]
test_relation_identification.py::TestTUmdTest::test_linear_column_incorrect_value PASSED                                              [ 65%]
test_relation_identification.py::TestTPmdTest::test_good_diff PASSED                                                                  [ 67%]
test_relation_identification.py::TestTPmdTest::test_slightly_wrong_diff PASSED                                                        [ 68%]
test_relation_identification.py::TestTPmdTest::test_wrong_diff PASSED                                                                 [ 70%]
test_relation_identification.py::TestTLsTest::test_good_slope SKIPPED (unconditional skip)                                            [ 71%]
test_relation_identification.py::TestTLsTest::test_wrong_slope PASSED                                                                 [ 72%]
test_relation_identification.py::TestTLsTest::test_slightly_wrong_slope SKIPPED (unconditional skip)                                  [ 74%]
test_relation_identification.py::TestMwwTest::test_linear_column_similar_values_with_by_column PASSED                                 [ 75%]
test_relation_identification.py::TestMwwTest::test_linear_column_similar_values_without_by_column PASSED                              [ 77%]
test_relation_identification.py::TestMwwTest::test_linear_column_different_values_with_by_column PASSED                               [ 78%]
test_relation_identification.py::TestWilcoxonTest::test_similar_columns PASSED                                                        [ 80%]
test_relation_identification.py::TestWilcoxonTest::test_similar_columns_with_by_column PASSED                                         [ 81%]
test_relation_identification.py::TestWilcoxonTest::test_different_columns PASSED                                                      [ 82%]
test_relation_identification.py::TestCanonicalCorr::test_strong_correlation PASSED                                                    [ 84%]
test_relation_identification.py::TestCanonicalCorr::test_weak_correlation PASSED                                                      [ 85%]
test_relation_identification.py::TestCanonicalCorr::test_no_correlation PASSED                                                        [ 87%]
test_relation_identification.py::TestAnovaCrdTest::test_simmilar_columns PASSED                                                       [ 88%]
test_relation_identification.py::TestAnovaCrdTest::test_dfferent_columns PASSED                                                       [ 90%]
test_relation_identification.py::TestAnovaCrdTest::test_multiple_columns_with_by_column PASSED                                        [ 91%]
test_relation_identification.py::TestAnovaRbdTest::test_one_column PASSED                                                             [ 92%]
test_relation_identification.py::TestAnovaRbdTest::test_multiple_columns PASSED                                                       [ 94%]
test_relation_identification.py::TestManovaOneWayTest::test_idependent_columns PASSED                                                 [ 95%]
test_relation_identification.py::TestManovaOneWayTest::test_correlated_columns PASSED                                                 [ 97%]
test_relation_identification.py::TestManovaTwoWayTest::test_correlated_columns PASSED                                                 [ 98%]
test_two_step_clustering.py::test_bisecting_kmeans PASSED                                                                             [100%]

============================================================= warnings summary ==============================================================
../../../../../../../../Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/future/standard_library/__init__.py:65
  /Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/site-packages/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================================== 63 passed, 7 skipped, 1 warning in 769.40s (0:12:49) ============================================
```