### PR TITLE
Hierarchical AutoDeleteContext

### DIFF
--- a/nzpyida/analytics/tests/test_auto_delete_context.py
+++ b/nzpyida/analytics/tests/test_auto_delete_context.py
@@ -55,7 +55,9 @@ class TestCurrentAutoDeleteContext:
     def test_nested_contexts(self, idadb):
         with AutoDeleteContext(idadb) as adc1:
             with AutoDeleteContext(idadb) as adc2:
-                assert adc1 == adc2
+                assert adc1 != adc2
+                assert adc2 == AutoDeleteContext.current()
+            assert adc1 == AutoDeleteContext.current()
 
 
 class TestAddTableToDelete:


### PR DESCRIPTION
Passed analytics unit tests:

```
Thu 25 9:28 tests % python3 -m pytest --hostname 9.30.57.160 --dsn telco --uid admin --pwd password
===================================================== test session starts ======================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/mpl/Documents/work/nzpyida
plugins: flaky-3.7.0
collected 71 items                                                                                                             

test_association_rules.py .                                                                                              [  1%]
test_auto_delete_context.py .......                                                                                      [ 11%]
test_bisecting_kmeans.py .                                                                                               [ 12%]
test_decision_trees.py .                                                                                                 [ 14%]
test_discretization.py ...                                                                                               [ 18%]
test_kmeans.py .                                                                                                         [ 19%]
test_knn.py .                                                                                                            [ 21%]
test_linear_regression.py s                                                                                              [ 22%]
test_model_manager.py .                                                                                                  [ 23%]
test_naive_bayes.py .                                                                                                    [ 25%]
test_preparation.py ...                                                                                                  [ 29%]
test_regression_trees.py .                                                                                               [ 30%]
test_relation_identification.py .......ss.......ss.........s.s.................                                          [ 97%]
test_timeseries.py .                                                                                                     [ 98%]
test_two_step_clustering.py .                                                                                            [100%]

======================================================= warnings summary =======================================================
../../../../../../../../opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65
  /opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 64 passed, 7 skipped, 1 warning in 1436.90s (0:23:56) =====================================

```