### PR TITLE
Proper handling of connection autocommit attribute

### DIFF
--- a/nzpyida/base.py
+++ b/nzpyida/base.py
@@ -222,7 +222,8 @@ class IdaDataBase(object):
                   self._database_system = 'netezza'
                   # for Netezza the internal connection is always in autocommit mode
                   # to allow explicit commits
-                  dsn += ';autocommit=false'
+                  if not autocommit:
+                    dsn += ';autocommit=false'
                   url_1stparam_del = ';'
               elif dsn.startswith('jdbc:db2:'):
                   self._database_system = 'db2'
@@ -307,6 +308,7 @@ class IdaDataBase(object):
             self._connection_string ={'user':user,'password':password,'host':host,
                 'port':port, 'database':database, 'securityLevel':securityLevel,'logLevel':logLevel}
             self._database_system = 'netezza'
+            self._con.autocommit = autocommit
 
         if self._con_type == 'odbc' :
 
@@ -323,7 +325,7 @@ class IdaDataBase(object):
 
             import pyodbc
             try:
-                self._con = pyodbc.connect(self._connection_string)
+                self._con = pyodbc.connect(self._connection_string, autocommit=autocommit)
                 self._con.setdecoding(pyodbc.SQL_CHAR, encoding='utf-8')
                 self._con.setdecoding(pyodbc.SQL_WCHAR, encoding='utf-8')
                 self._con.setencoding(encoding='utf-8')


### PR DESCRIPTION
Related to issue #55 

Unit tests passed:

```
Fri 26 16:17 tests % python3 -m pytest --hostname 9.30.57.160 --dsn telco --uid admin --pwd password
===================================================== test session starts ======================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/mpl/Documents/work/nzpyida
plugins: flaky-3.7.0
collected 492 items                                                                                                            

test_aggregation.py .................................                                                                    [  6%]
test_association_rules.py .........                                                                                      [  8%]
test_base.py .....s........ss..............                                                                              [ 14%]
test_base_connexion.py ............                                                                                      [ 17%]
test_base_private.py ......................                                                                              [ 21%]
test_base_table_manipulation.py ..s..sss..................                                                               [ 26%]
test_feature_selection.py ssssssssssss..........................................                                         [ 37%]
test_filtering.py ..........                                                                                             [ 39%]
test_frame.py ....................................................................s....                                  [ 54%]
test_frame_connexion.py ......                                                                                           [ 55%]
test_frame_private.py ........................                                                                           [ 60%]
test_geoFrame.py sssssssssssssssssssssssssssssss                                                                         [ 67%]
test_geoSeries.py sssssssssssssssssssssssssssssssssssssssssssssssss                                                      [ 77%]
test_indexing.py .....................                                                                                   [ 81%]
test_internals.py .....                                                                                                  [ 82%]
test_kmeans.py .........                                                                                                 [ 84%]
test_naive_bayes.py .........                                                                                            [ 85%]
test_series.py ...                                                                                                       [ 86%]
test_sorting.py ............                                                                                             [ 89%]
test_statistics.py ................................................                                                      [ 98%]
test_utils.py ......                                                                                                     [100%]

======================================================= warnings summary =======================================================
../../../../../../../opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65
  /opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

../base.py:1981
  /Users/mpl/Documents/work/nzpyida/nzpyida/base.py:1981: DeprecationWarning: invalid escape sequence '\_'
    """

../base.py:2000
  /Users/mpl/Documents/work/nzpyida/nzpyida/base.py:2000: DeprecationWarning: invalid escape sequence '\_'
    """

nzpyida/tests/test_aggregation.py: 3 warnings
nzpyida/tests/test_base.py: 1 warning
nzpyida/tests/test_base_private.py: 3 warnings
nzpyida/tests/test_base_table_manipulation.py: 5 warnings
nzpyida/tests/test_statistics.py: 2 warnings
nzpyida/tests/test_utils.py: 1 warning
  /Users/mpl/Documents/work/nzpyida/nzpyida/utils.py:241: UserWarning: Mixed case names are not supported in database object names.
    warnings.warn("Mixed case names are not supported in database object names.", UserWarning)

nzpyida/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idadf_getitem_slice
nzpyida/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idaseries_getitem_slice
  /Users/mpl/Documents/work/nzpyida/nzpyida/indexing.py:117: UserWarning: Row order is not guaranteed if no indexer was given and the dataset was not sorted
    warnings.warn("Row order is not guaranteed if no indexer" +

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_idadb_exists_model_negative passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
================================== 392 passed, 100 skipped, 20 warnings in 838.60s (0:13:58) ===================================

```