### PR TITLE
fix_out_table_failing_in_ADC

### DIFF
--- a/nzpyida/analytics/transform/preparation.py
+++ b/nzpyida/analytics/transform/preparation.py
@@ -236,9 +236,9 @@ def train_test_split(in_df: IdaDataFrame, out_table_train: str=None, out_table_t
         else:
             id_column = in_df.indexer
 
-    if in_df._idadb.exists_table_or_view(out_table_train):
+    if out_table_train and in_df._idadb.exists_table_or_view(out_table_train):
             in_df._idadb.drop_table(out_table_train)
-    if in_df._idadb.exists_table_or_view(out_table_test):
+    if out_table_test and in_df._idadb.exists_table_or_view(out_table_test):
             in_df._idadb.drop_table(out_table_test)
 
     temp_view_name, need_delete = materialize_df(in_df)

--- a/nzpyida/analytics/utils.py
+++ b/nzpyida/analytics/utils.py
@@ -124,7 +124,7 @@ def call_proc_df_in_out(proc: str, in_df: IdaDataFrame, params: dict,
     if not isinstance(in_df, IdaDataFrame):
         raise TypeError("Argument in_df should be an IdaDataFrame")
 
-    if in_df._idadb.exists_table_or_view(out_table):
+    if out_table and in_df._idadb.exists_table_or_view(out_table):
             in_df._idadb.drop_table(out_table)
 
     temp_view_name, need_delete = materialize_df(in_df)


### PR DESCRIPTION
```
============================================================= test session starts =============================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0 -- /Library/Frameworks/Python.framework/Versions/3.11/bin/python3
cachedir: .pytest_cache
rootdir: /Users/pawelmrz/Documents/persistent/nzpyida
plugins: flaky-3.7.0, anyio-3.6.2
collected 87 items                                                                                                                            

test_association_rules.py::test_arule PASSED                                                                                            [  1%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_context_present PASSED                                                  [  2%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_context_not_present PASSED                                              [  3%]
test_auto_delete_context.py::TestCurrentAutoDeleteContext::test_nested_contexts PASSED                                                  [  4%]
.
.
.
test_timeseries.py::test_timeseries PASSED                                                                                              [ 98%]
test_two_step_clustering.py::test_bisecting_kmeans PASSED                                                                               [100%]
=========================================== 80 passed, 7 skipped, 7 warnings in 2022.85s (0:33:42) ============================================
```