### PR TITLE
Correct handling of case sensitive name in descretization algorithm

### DIFF
--- a/nzpyida/analytics/transform/discretization.py
+++ b/nzpyida/analytics/transform/discretization.py
@@ -59,7 +59,7 @@ class Discretization:
         IdaDataFrame
             the data frame with discretization bins
         """
-        in_columns = ';'.join(in_df.columns)
+        in_columns = ';'.join(['"' + x + '"' for x in in_df.columns])
         params_dict = {
             'incolumn': in_columns,
             'outtabletype': 'table'


### PR DESCRIPTION
Fix for #52 

Unit tests results:

```
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/mpl/Documents/work/nzpyida
plugins: flaky-3.7.0, anyio-3.7.0
collected 87 items                                                                                                                                          

test_association_rules.py .                                                                                                                           [  1%]
test_auto_delete_context.py .......                                                                                                                   [  9%]
test_bayesian_networks.py .......                                                                                                                     [ 17%]
test_bisecting_kmeans.py .                                                                                                                            [ 18%]
test_cross_validation.py .                                                                                                                            [ 19%]
test_decision_trees.py .                                                                                                                              [ 20%]
test_discretization.py ...                                                                                                                            [ 24%]
test_glm.py .......                                                                                                                                   [ 32%]
test_kmeans.py .                                                                                                                                      [ 33%]
test_knn.py .                                                                                                                                         [ 34%]
test_linear_regression.py s                                                                                                                           [ 35%]
test_model_manager.py .                                                                                                                               [ 36%]
test_naive_bayes.py .                                                                                                                                 [ 37%]
test_preparation.py ....                                                                                                                              [ 42%]
test_regression_trees.py .                                                                                                                            [ 43%]
test_relation_identification.py .......ss.......ss.........s.s.................                                                                       [ 97%]
test_timeseries.py .                                                                                                                                  [ 98%]
test_two_step_clustering.py .                                                                                                                         [100%]

===================================================================== warnings summary ======================================================================
../../../../../../../../opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65
  /opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_2g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_2g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g2p
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g2p
  /Users/mpl/Documents/work/nzpyida/nzpyida/utils.py:241: UserWarning: Mixed case names are not supported in database object names.
    warnings.warn("Mixed case names are not supported in database object names.", UserWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================== 80 passed, 7 skipped, 7 warnings in 3005.19s (0:50:05) ===================================================


```