### PR TITLE
Fixing head() for IdaSeries

### DIFF
--- a/nzpyida/frame.py
+++ b/nzpyida/frame.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #-----------------------------------------------------------------------------
-# Copyright (c) 2015, IBM Corp.
+# Copyright (c) 2015-2023, IBM Corp.
 # All rights reserved.
 #
 # Distributed under the terms of the BSD Simplified License.
@@ -1076,13 +1076,12 @@ class IdaDataFrame(object):
             data = self.ida_query("SELECT * FROM %s %s LIMIT %s "%(name, order, nrow))
 
             if data.shape[0] != 0:
-                # otherwise column sort order is reverted
-                if not 'SELECT ' in name:
+                if isinstance(self, nzpyida.IdaSeries):
+                    data = data[self.column]
+                elif not 'SELECT ' in name:
                     columns = self.columns
                     data.columns = columns
 #                data = ibmdbpy.utils._convert_dtypes(self, data)
-                if isinstance(self, nzpyida.IdaSeries):
-                    data = pd.Series(data)
             return data
 
     # TODO : There is a warning in anaconda when there are missing values -> why ?

--- a/nzpyida/frame.py
+++ b/nzpyida/frame.py
@@ -1077,7 +1077,8 @@ class IdaDataFrame(object):
 
             if data.shape[0] != 0:
                 if isinstance(self, nzpyida.IdaSeries):
-                    data = data[self.column]
+                    if not isinstance(data, pd.Series):
+                        data = data[self.column]
                 elif not 'SELECT ' in name:
                     columns = self.columns
                     data.columns = columns


### PR DESCRIPTION
Fix for #64

Unit tests passed:

(General)
```
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/mpl/Documents/work/nzpyida
plugins: flaky-3.7.0, anyio-3.7.0
collected 492 items                                                                                                                                         

test_aggregation.py .................................                                                                                                 [  6%]
test_association_rules.py .........                                                                                                                   [  8%]
test_base.py .....s........ss..............                                                                                                           [ 14%]
test_base_connexion.py ............                                                                                                                   [ 17%]
test_base_private.py ......................                                                                                                           [ 21%]
test_base_table_manipulation.py ..s..sss..................                                                                                            [ 26%]
test_feature_selection.py ssssssssssss..........................................                                                                      [ 37%]
test_filtering.py ..........                                                                                                                          [ 39%]
test_frame.py ....................................................................s....                                                               [ 54%]
test_frame_connexion.py ......                                                                                                                        [ 55%]
test_frame_private.py ........................                                                                                                        [ 60%]
test_geoFrame.py sssssssssssssssssssssssssssssss                                                                                                      [ 67%]
test_geoSeries.py sssssssssssssssssssssssssssssssssssssssssssssssss                                                                                   [ 77%]
test_indexing.py .....................                                                                                                                [ 81%]
test_internals.py .....                                                                                                                               [ 82%]
test_kmeans.py .........                                                                                                                              [ 84%]
test_naive_bayes.py .........                                                                                                                         [ 85%]
test_series.py ...                                                                                                                                    [ 86%]
test_sorting.py ............                                                                                                                          [ 89%]
test_statistics.py ................................................                                                                                   [ 98%]
test_utils.py ......                                                                                                                                  [100%]

===================================================================== warnings summary ======================================================================
../../../../../../../opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65
  /opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

nzpyida/tests/test_aggregation.py: 3 warnings
nzpyida/tests/test_base.py: 1 warning
nzpyida/tests/test_base_private.py: 3 warnings
nzpyida/tests/test_base_table_manipulation.py: 5 warnings
nzpyida/tests/test_statistics.py: 2 warnings
nzpyida/tests/test_utils.py: 1 warning
  /Users/mpl/Documents/work/nzpyida/nzpyida/utils.py:241: UserWarning: Mixed case names are not supported in database object names.
    warnings.warn("Mixed case names are not supported in database object names.", UserWarning)

nzpyida/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idadf_getitem_slice
nzpyida/tests/test_frame.py::Test_IdaDataFrameBehavior::test_idaseries_getitem_slice
  /Users/mpl/Documents/work/nzpyida/nzpyida/indexing.py:117: UserWarning: Row order is not guaranteed if no indexer was given and the dataset was not sorted
    warnings.warn("Row order is not guaranteed if no indexer" +

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===Flaky Test Report===

test_idadb_exists_model_negative passed 1 out of the required 1 times. Success!

===End Flaky Test Report===
================================================= 392 passed, 100 skipped, 18 warnings in 603.43s (0:10:03) =================================================
```

(Analytics)
```
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/mpl/Documents/work/nzpyida
plugins: flaky-3.7.0, anyio-3.7.0
collected 87 items                                                                                                                                          

test_association_rules.py .                                                                                                                           [  1%]
test_auto_delete_context.py .......                                                                                                                   [  9%]
test_bayesian_networks.py .......                                                                                                                     [ 17%]
test_bisecting_kmeans.py .                                                                                                                            [ 18%]
test_cross_validation.py .                                                                                                                            [ 19%]
test_decision_trees.py .                                                                                                                              [ 20%]
test_discretization.py ...                                                                                                                            [ 24%]
test_glm.py .......                                                                                                                                                                                [ 32%]
test_kmeans.py .                                                                                                                                                                                   [ 33%]
test_knn.py .                                                                                                                                                                                      [ 34%]
test_linear_regression.py s                                                                                                                                                                        [ 35%]
test_model_manager.py .                                                                                                                                                                            [ 36%]
test_naive_bayes.py .                                                                                                                                                                              [ 37%]
test_preparation.py ....                                                                                                                                                                           [ 42%]
test_regression_trees.py .                                                                                                                                                                         [ 43%]
test_relation_identification.py .......ss.......ss.........s.s.................                                                                                                                    [ 97%]
test_timeseries.py .                                                                                                                                                                               [ 98%]
test_two_step_clustering.py .                                                                                                                                                                      [100%]

============================================================================================ warnings summary ============================================================================================
../../../../../../../../opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65
  /opt/homebrew/lib/python3.11/site-packages/future-0.18.3-py3.11.egg/future/standard_library/__init__.py:65: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
    import imp

nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_2g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_2g
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g2p
nzpyida/analytics/tests/test_bayesian_networks.py::test_tree_bayes_network_1g2p
  /Users/mpl/Documents/work/nzpyida/nzpyida/utils.py:241: UserWarning: Mixed case names are not supported in database object names.
    warnings.warn("Mixed case names are not supported in database object names.", UserWarning)

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 80 passed, 7 skipped, 7 warnings in 1771.45s (0:29:31) =========================================================================
```